### PR TITLE
fix: do not allow root blockHash to be set to 0x0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "eslint": "^8.11.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",
-    "faker": "5.5.3",
     "fishery": "^2.2.2",
     "husky": "^7.0.4",
     "jest": "^27.5.1",
@@ -50,6 +49,7 @@
     "cli-table3": "^0.6.1",
     "colors": "^1.4.0",
     "ethers": "^5.6.1",
+    "faker": "5.5.3",
     "neverthrow": "^4.3.1"
   },
   "lint-staged": {

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -206,6 +206,9 @@ class Engine {
   }
 
   private validateRoot(root: Root): boolean {
+    if (root.message.body.blockHash.length !== 66) {
+      return false;
+    }
     // TODO: Check that the blockHash is a real block and it's block matches rootBlock.
     // TODO: Check that prevRootBlockHash is either 0x0 or root block that we know about.
     return !!root;

--- a/src/simulation.ts
+++ b/src/simulation.ts
@@ -3,6 +3,7 @@ import Client from '~/client';
 import Debugger from '~/debugger';
 import FCNode, { InstanceName } from '~/node';
 import { isCast, isRoot } from '~/types';
+import Faker from 'faker';
 
 // 1. Create 5 Farcaster nodes
 const nodeList = new Map<InstanceName, FCNode>();
@@ -29,7 +30,7 @@ if (!knightNode) {
 const client = new Client('alice');
 
 // 5. Send two messages, sequentially to the node.
-const m1 = client.generateRoot(0, '0x0');
+const m1 = client.generateRoot(0, Faker.datatype.hexaDecimal(64).toLowerCase());
 knightNode.addRoot(m1);
 
 let lastMsg = knightNode.getLastMessage(client.username);
@@ -70,7 +71,7 @@ console.log('Client: starting a new chain');
 
 setTimeout(() => {
   Debugger.printState();
-  const b1 = client.generateRoot(1, '0x0', m1.message.body.blockHash);
+  const b1 = client.generateRoot(1, Faker.datatype.hexaDecimal(64).toLowerCase(), m1.message.body.blockHash);
   knightNode.addRoot(b1);
 }, 30_000);
 


### PR DESCRIPTION
The simulator incorrectly set rootBlockHash to 0x0, which is the symbol we use in prevRootBlockHash to indicate that we do not want chaining to happen. However, because the strings matched, the check actually passed and allowed the blocks to be chained together. 

The right fix is to ensure that each rootBlockHash is a valid ethereum blockhash, which won't be implemented until a later phase, so we are adding a quick validation to prevent these errors from being accidentally introduced.