### PR TITLE
feat: engine tracks signers for usernames

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -13,14 +13,18 @@ class Client {
     this.username = username;
   }
 
+  get address(): string {
+    return this.wallet.address;
+  }
+
   generateRoot(ethBlockNum: number, ethblockHash: string, prevRootBlockHash?: string): SignedMessage<RootMessageBody> {
     const item = {
       message: {
         body: {
           blockHash: ethblockHash,
           chainType: 'cast' as const,
-          prevRootBlockHash: prevRootBlockHash || '0x0', // TODO: change
-          prevRootLastHash: '0x0', // TODO: change, how are null props serialized.s
+          prevRootBlockHash: prevRootBlockHash || '0x0',
+          prevRootLastHash: '0x0',
           schema: 'farcaster.xyz/schemas/v1/root' as const,
         },
         index: 0,

--- a/src/debugger.ts
+++ b/src/debugger.ts
@@ -47,7 +47,7 @@ const Debugger = {
       // Determine the chain which has the user's latest message, so that we can mark it green.
       let latestSignedAt = 0;
       nodes.forEach((node) => {
-        const chainLatestSignedAt = latestChainSignedAt(node.engine.getCastChains(username));
+        const chainLatestSignedAt = latestChainSignedAt(node.engine.getChains(username));
         if (chainLatestSignedAt > latestSignedAt) {
           latestSignedAt = chainLatestSignedAt;
         }
@@ -55,9 +55,9 @@ const Debugger = {
 
       // For each user's chain in each node, print the chain.
       for (const node of nodes.values()) {
-        const chainLatestSignedAt = latestChainSignedAt(node.engine.getCastChains(username));
+        const chainLatestSignedAt = latestChainSignedAt(node.engine.getChains(username));
         const color = chainLatestSignedAt === latestSignedAt ? colors.green : colors.red;
-        table.push({ [node.name]: visualizeChains(node.engine.getCastChains(username), color) });
+        table.push({ [node.name]: visualizeChains(node.engine.getChains(username), color) });
       }
     }
 

--- a/src/factories.ts
+++ b/src/factories.ts
@@ -83,4 +83,25 @@ export const Factories = {
       signer: '',
     };
   }),
+
+  /** Generate a new ETH Address with its corresponding private key */
+  EthAddress: Factory.define<EthAddress, any, EthAddress>(({ onCreate }) => {
+    onCreate(async (addressProps) => {
+      const wallet = new ethers.Wallet(addressProps.privateKey);
+      addressProps.address = await wallet.getAddress();
+      return addressProps;
+    });
+
+    const privateKey = Faker.datatype.hexaDecimal(64).toLowerCase();
+
+    return {
+      address: '',
+      privateKey,
+    };
+  }),
 };
+
+interface EthAddress {
+  address: string;
+  privateKey: string;
+}

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,6 +1,7 @@
 import { Cast, Root, SignedCastChain, SignedCastChainFragment, SignedMessage } from '~/types';
 import Engine, { ChainFingerprint } from '~/engine';
 import { isCast, isRoot } from '~/types/typeguards';
+import { Result } from 'neverthrow';
 
 /** The Node brokers messages to clients and peers and passes new messages into the Engine for resolution  */
 class FCNode {
@@ -106,13 +107,13 @@ class FCNode {
    */
 
   /** Start a new chain for the user */
-  addRoot(root: Root): void {
-    this.engine.addRoot(root);
+  addRoot(root: Root): Result<void, string> {
+    return this.engine.addRoot(root);
   }
 
   /** Merge a single message into the latest chain */
   addCast(Cast: Cast): void {
-    this.engine.addCast(Cast);
+    return this.engine.addCast(Cast);
   }
 
   /** Merge a partial chain into the latest chain */


### PR DESCRIPTION
The Engine now keeps track of simulated "Signer Change" events from the Farcaster Registry. From now on,  Roots - and by extension, Casts - will only be accepted if the signer address owned the username at the block specified in the Root.
